### PR TITLE
Add a GitHub build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,15 @@ jobs:
       with:
         repository: miracoli/Saturn-SDK-GCC-SH2
         path: Saturn-SDK-GCC-SH2
+    - name: Get toolchain commit
+      run: echo "toolchaincommit=$(git rev-parse HEAD)" >> $GITHUB_ENV
+      working-directory: Saturn-SDK-GCC-SH2
     - name: Restore cached toolchain
-      # TODO: better cache key - commit ID for toolchain repo?
       uses: actions/cache@v2
       id: toolchaincache
       with:
         path: Saturn-SDK-GCC-SH2/toolchain
-        key: toolchain
+        key: toolchain-${{ env.toolchaincommit }}
     - name: Build toolchain
       # Only build if we don't have a cached version
       if: steps.toolchaincache.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
     - name: Build toolchain
       # based on https://github.com/miracoli/Saturn-SDK-GCC-SH2/blob/master/.github/workflows/build.yml
       # manual install of automake 1.16 only required on ubuntu < 20.04
+      # TODO: step takes >15 mins so cache output https://github.com/actions/cache#Skipping-steps-based-on-cache-hit
       run: |
         if [ "$RUNNER_OS" == "macOS" ]; then
               brew install coreutils
@@ -50,9 +51,14 @@ jobs:
         sudo apt-get -y install cmake
         make
       working-directory: satiator-menu
-      
+    - name: Upload config.log artifact
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: configlogs
+        path: '**/config.log'
     - name: Upload menu.bin artifact
       uses: actions/upload-artifact@v2
       with:
         name: menu.bin
-        path: satiator-menu/menu.bin
+        path: satiator-menu/out/menu.bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,18 +14,21 @@ jobs:
       with:
         path: satiator-menu
         submodules: true
-    - name: Restore cached toolchain
-      # Restoring before checkout should let files be overwritten if needed while still allowing incremental builds?
-      uses: actions/cache@v2
-      with:
-        path: Saturn-SDK-GCC-SH2
-        key: toolchain
     - name: Check out toolchain
       uses: actions/checkout@v2
       with:
         repository: miracoli/Saturn-SDK-GCC-SH2
         path: Saturn-SDK-GCC-SH2
+    - name: Restore cached toolchain
+      # TODO: better cache key - commit ID for toolchain repo?
+      uses: actions/cache@v2
+      id: toolchaincache
+      with:
+        path: Saturn-SDK-GCC-SH2/toolchain
+        key: toolchain
     - name: Build toolchain
+      # Only build if we don't have a cached version
+      if: steps.toolchaincache.outputs.cache-hit != 'true'
       # based on https://github.com/miracoli/Saturn-SDK-GCC-SH2/blob/master/.github/workflows/build.yml
       # manual install of automake 1.16 only required on ubuntu < 20.04
       run: |
@@ -37,7 +40,6 @@ jobs:
         sudo apt-get -y install ./automake_1.16.1-4_all.deb
         sudo apt-get -y install automake autoconf autoconf-archive autotools-dev bison texinfo
         ./build-elf.sh
-        echo '${{ github.workspace }}/Saturn-SDK-GCC-SH2/toolchain/bin' >> $GITHUB_PATH
       working-directory: Saturn-SDK-GCC-SH2
       env: 
         SRCDIR: ${{ github.workspace }}/Saturn-SDK-GCC-SH2/source
@@ -51,6 +53,8 @@ jobs:
         DOWNLOADDIR:  ${{ github.workspace }}/Saturn-SDK-GCC-SH2/download
         PROGRAM_PREFIX: sh-none-
         NCPU: 2
+    - name: Add toolchain to path
+      run: echo '${{ github.workspace }}/Saturn-SDK-GCC-SH2/toolchain/bin' >> $GITHUB_PATH
     - name: Build satiator-menu
       run: |
         sudo apt-get -y install cmake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Check out satiator-menu
+      # user/org needs to have a fork of iapetus as submodule is defined as ../iapetus.git
+      uses: actions/checkout@v2
+      with:
+        path: satiator-menu
+        submodules: true
     - name: Check out toolchain
       uses: actions/checkout@v2
       with:
@@ -40,12 +46,6 @@ jobs:
         DOWNLOADDIR:  ${{ github.workspace }}/Saturn-SDK-GCC-SH2/download
         PROGRAM_PREFIX: sh-none-
         NCPU: 2
-    - name: Check out satiator-menu
-      # user/org needs to have a fork of iapetus as submodule is defined as ../iapetus.git
-      uses: actions/checkout@v2
-      with:
-        path: satiator-menu
-        submodules: true
     - name: Build satiator-menu
       run: |
         sudo apt-get -y install cmake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,58 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out toolchain
+      uses: actions/checkout@v2
+      with:
+        repository: miracoli/Saturn-SDK-GCC-SH2
+        path: Saturn-SDK-GCC-SH2
+    - name: Build toolchain
+      # based on https://github.com/miracoli/Saturn-SDK-GCC-SH2/blob/master/.github/workflows/build.yml
+      # manual install of automake 1.16 only required on ubuntu < 20.04
+      run: |
+        if [ "$RUNNER_OS" == "macOS" ]; then
+              brew install coreutils
+        fi
+        echo SRCDIR $SRCDIR BUILDDIR $BUILDDIR TARGETMACH $TARGETMACH BUILDMACH $BUILDMACH HOSTMACH $HOSTMACH INSTALLDIR $INSTALLDIR SYSROOTDIR $SYSROOTDIR ROOTDIR $ROOTDIR DOWNLOADDIR $DOWNLOADDIR PROGRAM_PREFIX $PROGRAM_PREFIX
+        wget http://ftp.br.debian.org/debian/pool/main/a/automake-1.16/automake_1.16.1-4_all.deb
+        sudo apt-get -y install ./automake_1.16.1-4_all.deb
+        sudo apt-get -y install automake autoconf autoconf-archive autotools-dev bison texinfo
+        ./build-elf.sh
+        echo '${{ github.workspace }}/Saturn-SDK-GCC-SH2/toolchain/bin' >> $GITHUB_PATH
+      working-directory: Saturn-SDK-GCC-SH2
+      env: 
+        SRCDIR: ${{ github.workspace }}/Saturn-SDK-GCC-SH2/source
+        BUILDDIR:  ${{ github.workspace }}/Saturn-SDK-GCC-SH2/build
+        TARGETMACH: sh-elf
+        BUILDMACH: x86_64-pc-linux-gnu
+        HOSTMACH: x86_64-pc-linux-gnu
+        INSTALLDIR:  ${{ github.workspace }}/Saturn-SDK-GCC-SH2/toolchain
+        SYSROOTDIR: ${{ github.workspace }}/Saturn-SDK-GCC-SH2/toolchain/sysroot
+        ROOTDIR:  ${{ github.workspace }}
+        DOWNLOADDIR:  ${{ github.workspace }}/Saturn-SDK-GCC-SH2/download
+        PROGRAM_PREFIX: sh-none-
+        NCPU: 2
+    - name: Check out satiator-menu
+      # user/org needs to have a fork of iapetus as submodule is defined as ../iapetus.git
+      uses: actions/checkout@v2
+      with:
+        path: satiator-menu
+        submodules: true
+    - name: Build satiator-menu
+      run: |
+        sudo apt-get -y install cmake
+        make
+      working-directory: satiator-menu
+      
+    - name: Upload menu.bin artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: menu.bin
+        path: satiator-menu/menu.bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,12 @@ jobs:
       with:
         path: satiator-menu
         submodules: true
+    - name: Restore cached toolchain
+      # Restoring before checkout should let files be overwritten if needed while still allowing incremental builds?
+      uses: actions/cache@v2
+      with:
+        path: Saturn-SDK-GCC-SH2
+        key: toolchain
     - name: Check out toolchain
       uses: actions/checkout@v2
       with:
@@ -22,7 +28,6 @@ jobs:
     - name: Build toolchain
       # based on https://github.com/miracoli/Saturn-SDK-GCC-SH2/blob/master/.github/workflows/build.yml
       # manual install of automake 1.16 only required on ubuntu < 20.04
-      # TODO: step takes >15 mins so cache output https://github.com/actions/cache#Skipping-steps-based-on-cache-hit
       run: |
         if [ "$RUNNER_OS" == "macOS" ]; then
               brew install coreutils


### PR DESCRIPTION
This is mostly my notes from building satiator-menu so it doubles as a sort of build documentation, and also produce an artifact containing menu.bin. I realised part way that you're already using GitLab for some CI, but I think the build indicators and the fact forks can turn it on to get builds easily for testing might still have some value?

The build uses https://github.com/miracoli/Saturn-SDK-GCC-SH2/ which is cached to avoid the 15+ minutes it takes to build, so a run is usually 2-3 minutes.